### PR TITLE
Update github KexAlgorithms

### DIFF
--- a/_posts/2015-01-04-secure-secure-shell.md
+++ b/_posts/2015-01-04-secure-secure-shell.md
@@ -90,9 +90,9 @@ Recommended `/etc/ssh/sshd_config` snippet:
 
 Recommended `/etc/ssh/ssh_config` snippet:
 
-<pre><code># Github needs diffie-hellman-group-exchange-sha1 some of the time but not always.
+<pre><code># Github needs different Algorithms some of the time but not always.
 #Host github.com
-#    KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1
+#    KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1
     
 Host *
     KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256</code></pre>

--- a/_posts/2015-01-04-secure-secure-shell.md
+++ b/_posts/2015-01-04-secure-secure-shell.md
@@ -90,7 +90,7 @@ Recommended `/etc/ssh/sshd_config` snippet:
 
 Recommended `/etc/ssh/ssh_config` snippet:
 
-<pre><code># Github needs different Algorithms some of the time but not always.
+<pre><code># Github needs different algorithms some of the time but not always.
 #Host github.com
 #    KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1
     


### PR DESCRIPTION
That KexAlgorithms list did not work with github in my case. It needs `diffie-hellman-group1-sha1` or `diffie-hellman-group14-sha1` for to allow ssh to connect.