### PR TITLE
remove `ssh-rsa-cert-v00@openssh.com` from `HostKeyAlgorithms`

### DIFF
--- a/_posts/2015-01-04-secure-secure-shell.md
+++ b/_posts/2015-01-04-secure-secure-shell.md
@@ -182,7 +182,7 @@ Recommended `/etc/ssh/ssh_config` snippet:
 
 <pre><code id="client-auth-pubkey">Host *
     PubkeyAuthentication yes
-    HostKeyAlgorithms ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ssh-rsa-cert-v00@openssh.com,ssh-ed25519,ssh-rsa</code></pre>
+    HostKeyAlgorithms ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ssh-ed25519,ssh-rsa</code></pre>
 
 Generate client keys using the following commands:
 


### PR DESCRIPTION
It is not supported as of OpenSSH 7.0:
http://www.openssh.com/txt/release-7.0:
```
Support for the legacy v00 cert format has been removed.
```