### PR TITLE
Added the -N "" for host key generation

### DIFF
--- a/_posts/2015-01-04-secure-secure-shell.md
+++ b/_posts/2015-01-04-secure-secure-shell.md
@@ -150,8 +150,8 @@ If you don't want that, remove any `ssh-keygen` commands from the init script.
 
 <pre><code id="server-keygen">cd /etc/ssh
 rm ssh_host_*key*
-ssh-keygen -t ed25519 -f ssh_host_ed25519_key < /dev/null
-ssh-keygen -t rsa -b 4096 -f ssh_host_rsa_key < /dev/null</code></pre>
+ssh-keygen -t ed25519 -f ssh_host_ed25519_key -N "" < /dev/null
+ssh-keygen -t rsa -b 4096 -f ssh_host_rsa_key -N "" < /dev/null</code></pre>
 
 ### Client authentication
 


### PR DESCRIPTION
When I was going through the document step by step, I found that it would be a good thing to either mention not to set a passphrase for the host key generation or just add the `-N ""` option for the host key generation to avoid accidental setup of a passphrase for the host keys rendering them unusable to sshd.

I am uncertain about the `< /dev/null` redirect. I have tested it ssh-keygen still outputs stdout to the shell.
Or was there another reason for this to be there?

Any thoughts?
