### PR TITLE
Update algorithm choices

### DIFF
--- a/_posts/2015-01-04-secure-secure-shell.md
+++ b/_posts/2015-01-04-secure-secure-shell.md
@@ -285,7 +285,6 @@ Here are the available MAC choices:
 
 1. hmac-md5
 1. hmac-md5-96
-1. hmac-ripemd160
 1. hmac-sha1
 1. hmac-sha1-96
 1. hmac-sha2-256
@@ -294,7 +293,6 @@ Here are the available MAC choices:
 1. umac-128
 1. hmac-md5-etm@openssh.com
 1. hmac-md5-96-etm@openssh.com
-1. hmac-ripemd160-etm@openssh.com
 1. hmac-sha1-etm@openssh.com
 1. hmac-sha1-96-etm@openssh.com
 1. hmac-sha2-256-etm@openssh.com
@@ -321,12 +319,12 @@ The selection considerations:
 
 Recommended `/etc/ssh/sshd_config` snippet:
 
-<pre><code id="server-macs">MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com</code></pre>
+<pre><code id="server-macs">MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com</code></pre>
 
 Recommended `/etc/ssh/ssh_config` snippet:
 
 <pre><code id="client-macs">Host *
-    MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com</code></pre>
+    MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com</code></pre>
 
 # Preventing key theft
 

--- a/_posts/2015-01-04-secure-secure-shell.md
+++ b/_posts/2015-01-04-secure-secure-shell.md
@@ -459,7 +459,7 @@ I promise not to use `git push -f`.
 [rfc4253]: https://www.ietf.org/rfc/rfc4253.txt
 [rfc4419]: https://www.ietf.org/rfc/rfc4419.txt
 [ed25519]: http://ed25519.cr.yp.to/
-[google-auth]: https://code.google.com/p/google-authenticator/wiki/PamModuleInstructions
+[google-auth]: https://github.com/google/google-authenticator/wiki/PAM-Module-Instructions
 [totp]: https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm
 [otp]: https://www.cl.cam.ac.uk/~mgk25/otpw.html
 [pam]: https://en.wikipedia.org/wiki/Pluggable_authentication_module

--- a/_posts/2015-01-04-secure-secure-shell.md
+++ b/_posts/2015-01-04-secure-secure-shell.md
@@ -60,11 +60,14 @@ Pb          <-- Pb = Sb * G
 s = Sa * Pb     s = Sb * Pa
 k = KDF(s)      k = KDF(s)</code></pre>
 
-OpenSSH supports 8 key exchange protocols:
+OpenSSH supports 11 key exchange protocols:
 
 1. [curve25519-sha256][libsshdoc]: ECDH over [Curve25519][curve25519] with SHA2
 1. [diffie-hellman-group1-sha1][rfc4253]: 1024 bit DH with SHA1
 1. [diffie-hellman-group14-sha1][rfc4253]: 2048 bit DH with SHA1
+1. [diffie-hellman-group14-sha256][dh-draft]: 2048 bit DH with SHA2
+1. [diffie-hellman-group16-sha512][dh-draft]: 4096 bit DH with SHA2
+1. [diffie-hellman-group18-sha512][dh-draft]: 8192 bit DH with SHA2
 1. [diffie-hellman-group-exchange-sha1][rfc4419]: Custom DH with SHA1
 1. [diffie-hellman-group-exchange-sha256][rfc4419]: Custom DH with SHA2
 1. ecdh-sha2-nistp256: ECDH over NIST P-256 with SHA2
@@ -74,18 +77,18 @@ OpenSSH supports 8 key exchange protocols:
 We have to look at 3 things here:
 
 * *ECDH curve choice*:
-  This eliminates 6-8 because [NIST curves suck][nist-sucks].
+  This eliminates 8-11 because [NIST curves suck][nist-sucks].
   They leak secrets through timing side channels and off-curve inputs.
   Also, [NIST is considered harmful][bullrun] and cannot be trusted.
 * *Bit size of the DH modulus*:
   This eliminates 2 because the NSA has supercomputers and possibly unknown attacks.
   1024 bits simply don't offer sufficient security margin.
 * *Security of the hash function*:
-  This eliminates 2-4 because SHA1 is broken.
+  This eliminates 2, 3, and 7 because SHA1 is broken.
   We don't have to wait for a second preimage attack that takes 10 minutes on a cellphone to disable it right now.
 
-We are left with 1 and 5.
-1 is better and it's perfectly OK to only support that but for interoperability (with Eclipse, WinSCP), 5 can be included.
+We are left with 1 and 8, as well as 4-6 which were added in [OpenSSH 7.3][73release].
+1 is better and it's perfectly OK to only support that but for interoperability (with Eclipse, WinSCP), 8 can be included.
 
 Recommended `/etc/ssh/sshd_config` snippet:
 
@@ -100,7 +103,7 @@ Recommended `/etc/ssh/ssh_config` snippet:
 Host *
     KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256</code></pre>
 
-If you chose to enable 5, open `/etc/ssh/moduli` if exists, and delete lines where the 5th column is less than 2000.
+If you chose to enable 8, open `/etc/ssh/moduli` if exists, and delete lines where the 5th column is less than 2000.
 
 <pre><code id="server-moduli-filter">awk '$5 > 2000' /etc/ssh/moduli > "${HOME}/moduli"
 wc -l "${HOME}/moduli" # make sure there is something left
@@ -457,6 +460,8 @@ I promise not to use `git push -f`.
 [libsshdoc]: http://git.libssh.org/projects/libssh.git/tree/doc/curve25519-sha256@libssh.org.txt
 [curve25519]: http://cr.yp.to/ecdh.html
 [rfc4253]: https://www.ietf.org/rfc/rfc4253.txt
+[dh-draft]: https://tools.ietf.org/html/draft-ietf-curdle-ssh-modp-dh-sha2-09
+[73release]: https://www.openssh.com/releasenotes.html#7.3
 [rfc4419]: https://www.ietf.org/rfc/rfc4419.txt
 [ed25519]: http://ed25519.cr.yp.to/
 [google-auth]: https://github.com/google/google-authenticator/wiki/PAM-Module-Instructions

--- a/_posts/2015-01-04-secure-secure-shell.md
+++ b/_posts/2015-01-04-secure-secure-shell.md
@@ -213,7 +213,7 @@ Create the ssh-user group with `sudo groupadd ssh-user`, then add each ssh user 
 
 Symmetric ciphers are used to encrypt the data after the initial key exchange and authentication is complete.
 
-Here we have quite a few algorithms:
+Here we have quite a few algorithms (10-14 were removed in [OpenSSH 7.6][76release]):
 
 1. 3des-cbc
 1. aes128-cbc
@@ -462,6 +462,7 @@ I promise not to use `git push -f`.
 [rfc4253]: https://www.ietf.org/rfc/rfc4253.txt
 [dh-draft]: https://tools.ietf.org/html/draft-ietf-curdle-ssh-modp-dh-sha2-09
 [73release]: https://www.openssh.com/releasenotes.html#7.3
+[76release]: https://www.openssh.com/releasenotes.html#7.6
 [rfc4419]: https://www.ietf.org/rfc/rfc4419.txt
 [ed25519]: http://ed25519.cr.yp.to/
 [google-auth]: https://github.com/google/google-authenticator/wiki/PAM-Module-Instructions


### PR DESCRIPTION
- Remove hmac-ripemd160 which was removed in [OpenSSH 7.6](https://www.openssh.com/releasenotes.html#7.6).
- Note the removal of arcfour, blowfish, and CAST in [7.6](https://www.openssh.com/releasenotes.html#7.6).
- Add the new Diffie-Hellman key exchange algorithms from [7.3](https://www.openssh.com/releasenotes.html#7.3).
- Fix the dead Google Authenticator link with its news location on GitHub.

I wasn't sure if you would want me to actually remove arcfour/blowfish/cast from the cipher list instead of just noting their removal in the most recent version. I'm happy to revise it if you do. You're welcome to cherry-pick or merge that from cbdf0e3cba2d0dad501bc6f1f23d46da94f9c866 if you'd like.

I also wasn't sure if you'd want to update the recommended snippet with any of the new DH groups. Based on [this draft](https://tools.ietf.org/html/draft-ietf-curdle-ssh-kex-sha2-09) it sounds like group14-sha256 is a good choice and the other two are likely overkill currently. OpenSSH 7.3 has been out for more than a year, but I do know some people run ancient software. You're also welcome to grab those more opinionated changes from 1c6f78961d8cb9450a1ba7864dec58ec660b651b.